### PR TITLE
remove *Rdata from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
-.RData
 .Ruserdata
 .gitignore
 tests/*


### PR DESCRIPTION
I noticed some problems with ScopeLoomR when installing via `devtools::install_github('aertslab/SCopeLoomR')`

I would get an error when trying to load the datasets:

```
> library(SCopeLoomR)
> data(sce)
Warning message:
In data(sce) : data set ‘sce’ not found
> 
```

Here's the standard output when installing the package:
```
> devtools::install_github('aertslab/SCopeLoomR')
Downloading GitHub repo aertslab/SCopeLoomR@HEAD
   checking for file ‘/private/var/folders/pt/x80rw07n57q7h9tdwt97nvfh0000gn/T/RtmpDFD6OR/remotes11ab470539499/aertslab-SCopeLoomR-6932✔  checking for file ‘/private/var/folders/pt/x80rw07n57q7h9tdwt97nvfh0000gn/T/RtmpDFD6OR/remotes11ab470539499/aertslab-SCopeLoomR-6932a4d/DESCRIPTION’
─  preparing ‘SCopeLoomR’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
   Removed empty directory ‘SCopeLoomR/data’
─  building ‘SCopeLoomR_0.9.3.tar.gz’
...
```
The line ` Removed empty directory ‘SCopeLoomR/data’` shows the directory is empty. I think that's because of the line in `.Rbuildignore`. I've removed it.
