### PR TITLE
Added helpful suggestions for get_regulons functions

### DIFF
--- a/R/loom.R
+++ b/R/loom.R
@@ -2217,9 +2217,11 @@ get_cellAnnotation <- function(loom, annotCols=NULL)
 get_regulonsAuc <- function(loom, attrName="MotifRegulonsAUC", rows="regulons", columns="cells") {
   if(!attrName %in% names(loom[["col_attrs"]]))
   {
-    msg <- "The argument 'attrName' is not available in this loom file."
+    msg <- paste("The attribute '", attrName, "' is not available in this loom file.", sep='')
     possibleValues <- grep("egulon", names(loom[["col_attrs"]]), value=T)
-    if(length(possibleValues)>0) msg <- c(msg, " Possible values include: ", paste(possibleValues, collapse=", "),".")
+    if(length(possibleValues)>0) msg <- c(msg, " Possible values include: ", paste(possibleValues, collapse=", "),
+                                          paste(". Try setting the 'attrName' argument to one of these values (i.e., get_regulonsAuc(loom, attrName='", possibleValues[1], "')).", sep="")
+                                          )
     if(length(possibleValues)==0) msg <- c(msg, " The loom doesn't contain regulon information.")
     stop(msg)
   }
@@ -2254,9 +2256,11 @@ get_regulonsAuc <- function(loom, attrName="MotifRegulonsAUC", rows="regulons", 
 get_regulons <- function(loom, attrName="MotifRegulons", tfAsName=TRUE, tfSep="_"){
   if(!attrName %in% names(loom[["row_attrs"]]))
   {
-    msg <- "The argument 'attrName' is not available in this loom file."
+    msg <- paste("The attribute '", attrName, "' is not available in this loom file.", sep='')
     possibleValues <- grep("egulon", names(loom[["row_attrs"]]), value=T)
-    if(length(possibleValues)>0) msg <- c(msg, " Possible values include: ", paste(possibleValues, collapse=", "),".")
+    if(length(possibleValues)>0) msg <- c(msg, " Possible values include: ", paste(possibleValues, collapse=", "),
+                                          paste(". Try setting the 'attrName' argument to one of these values (i.e., get_regulons(loom, attrName='", possibleValues[1], "')).", sep="")
+                                          )
     if(length(possibleValues)==0) msg <- c(msg, " The loom doesn't contain regulon information.")
     stop(msg)
   }


### PR DESCRIPTION
I recently had an issue in pySCENIC (aertslab/pySCENIC/issues/195) where the `get_regulons` function no longer worked the way it used to. It seems that the the default attribute was changed in 0f2325d. Here, I added some additional info to the error message to help the user by printing suggestions based on the attributes discovered in the loom file.

(Maybe this is also related to #16.)